### PR TITLE
Add Prefix to Metric Name

### DIFF
--- a/hubitat2prom/PrometheusExporter/ExporterHubitatDeviceMetric.cs
+++ b/hubitat2prom/PrometheusExporter/ExporterHubitatDeviceMetric.cs
@@ -38,7 +38,7 @@ public class ExporterHubitatDeviceMetric
     /// Formats the line Prometheus needs to ingest a metric.
     /// </summary>
     /// <returns>
-    /// This looks like, e.g., `switch{device_name="light_switch"} 1.0`
+    /// This looks like, e.g., `hubitat_switch{device_name="light_switch"} 1.0`
     /// </returns>
 
     public override string ToString() => $"hubitat_{MetricName}{{device_name=\"{DeviceName}\"}} {_metricValue}".ToLowerInvariant();

--- a/hubitat2prom/PrometheusExporter/ExporterHubitatDeviceMetric.cs
+++ b/hubitat2prom/PrometheusExporter/ExporterHubitatDeviceMetric.cs
@@ -41,5 +41,5 @@ public class ExporterHubitatDeviceMetric
     /// This looks like, e.g., `switch{device_name="light_switch"} 1.0`
     /// </returns>
 
-    public override string ToString() => $"{MetricName}{{device_name=\"{DeviceName}\"}} {_metricValue}".ToLowerInvariant();
+    public override string ToString() => $"hubitat_{MetricName}{{device_name=\"{DeviceName}\"}} {_metricValue}".ToLowerInvariant();
 }


### PR DESCRIPTION
The documents recommend adding a prefix to your metric name.

https://prometheus.io/docs/practices/naming/

This update adds the `hubitat_` prefix