### PR TITLE
Resolve crash caused by device drivers returning invalid values for k…

### DIFF
--- a/hubitat2prom.Tests/Data/AllDeviceDetails.json
+++ b/hubitat2prom.Tests/Data/AllDeviceDetails.json
@@ -7,13 +7,14 @@
         "date": "2022-03-03T14:20:00+0000",
         "model": null,
         "manufacturer": null,
+        "room": "Kitchen",
         "capabilities": [
             "Configuration",
-        "Actuator",
-        "Refresh",
-        "HoldableButton",
-        "Switch",
-        "PushableButton"
+            "Actuator",
+            "Refresh",
+            "HoldableButton",
+            "Switch",
+            "PushableButton"
         ],
         "attributes": {
             "dataType": "STRING",
@@ -25,33 +26,57 @@
             "syncStatus": "1 Pending Changes"
         },
         "commands": [
-        {
-            "command": "configure"
-        },
-        {
-            "command": "hold"
-        },
-        {
-            "command": "off"
-        },
-        {
-            "command": "on"
-        },
-        {
-            "command": "paramCommands"
-        },
-        {
-            "command": "push"
-        },
-        {
-            "command": "refresh"
-        },
-        {
-            "command": "setLED"
-        },
-        {
-            "command": "setLEDMode"
-        }
+            {
+                "command": "configure"
+            },
+            {
+                "command": "hold"
+            },
+            {
+                "command": "off"
+            },
+            {
+                "command": "on"
+            },
+            {
+                "command": "paramCommands"
+            },
+            {
+                "command": "push"
+            },
+            {
+                "command": "refresh"
+            },
+            {
+                "command": "setLED"
+            },
+            {
+                "command": "setLEDMode"
+            }
         ]
+    },
+    {
+        "name": "Hygrometer - Living Room",
+        "label": "Hygrometer - Living Room",
+        "type": "Zooz ZSE44 Temperature Humidity XS Sensor",
+        "id": "1360",
+        "date": "2022-12-27T16:40:39+0000",
+        "model": null,
+        "manufacturer": null,
+        "room": "Living Room",
+        "capabilities": [
+            "RelativeHumidityMeasurement",
+            "Battery",
+            "TemperatureMeasurement",
+            "Sensor"
+        ],
+        "attributes": {
+            "humidity": "18",
+            "dataType": "NUMBER",
+            "values": null,
+            "battery": "73",
+            "temperature": "29.0"
+        },
+        "commands": []
     }
 ]

--- a/hubitat2prom/ExceptionExtensions.cs
+++ b/hubitat2prom/ExceptionExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Diagnostics;
+
+namespace hubitat2prom
+{
+    public static class ExceptionExtensions
+    {
+        private const string TRACE_DATETIME_FORMAT = "{0:[yyyy-MM-ddThh:mm:ss.fffK]} {1}";
+        public static void TraceError(this Exception e)
+            => Trace.TraceError(TRACE_DATETIME_FORMAT, DateTime.Now, e);
+        public static void TraceError(this Exception e, string message)
+        {
+            Trace.TraceError(TRACE_DATETIME_FORMAT, DateTime.Now, message);
+            TraceError(e);
+        }
+    }
+}

--- a/hubitat2prom/ReflectionExtensions.cs
+++ b/hubitat2prom/ReflectionExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection;
+
+namespace hubitat2prom
+{
+    public static class ReflectionExtensions
+    {
+        public static string FriendlyName(this object obj)
+            => FriendlyName(obj.GetType());
+
+        public static string FriendlyName(this PropertyInfo propertyInfo)
+            => FriendlyName(propertyInfo.PropertyType);
+
+        public static string FriendlyName(this Type type)
+        {
+            var name = "";
+            if (type.Namespace != null)
+            {
+                name += type.Namespace + ".";
+            }
+            name += type.Name;
+
+            if (!type.IsGenericType) return name;
+
+            name += "[";
+
+            var seperator = "";
+
+            foreach (var t in type.GetGenericArguments())
+            {
+                name += seperator + FriendlyName(t);
+                seperator = ", ";
+            }
+
+            name += "]";
+
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
…nown attribute types.

Specifically, this device driver for "battery" reporting may return the string "unknown" instead of a number. https://raw.githubusercontent.com/ymerj/HE-HA-control/main/genericComponentBattery.groovy This fix corrects a crash that would occur when a type cannot be deserialized/converted to the expected attribute type for known device attributes. Rather than crashing, the error is logged along with some information helpful to diagnose and correct what caused it. The attribute is then ignored, though hubitat2prom will continue to ingest and try to report on the attribute for subsequent requests.

See this thread for more information. https://community.hubitat.com/t/release-prometheus-device-metrics-hubitat2prom-in-c/90365/4

Closes #2